### PR TITLE
chore: fix subprocess for actions

### DIFF
--- a/fix-yaml/__main__.py
+++ b/fix-yaml/__main__.py
@@ -25,11 +25,11 @@ settings = Settings()
 
 logging.info("Setting up GitHub Actions git user")
 subprocess.run(
-    ["git", "config", "user.name", settings.input_username],
+    ["git", "config", "--global", "user.name", settings.input_username],
     check=True,
 )
 subprocess.run(
-    ["git", "config", "user.email", settings.input_useremail],
+    ["git", "config", "--global", "user.email", settings.input_useremail],
     check=True,
 )
 


### PR DESCRIPTION
**리뷰어가 작업내용을 이해하기 쉽도록 아래내용을 상세히 작성해주세요.**

## Changes

- git config 전역으로 등록 `--global`
	
## 효과

- alpha-actions 내에서 사용할 때에 checkout step 없이 진행할 경우
	`fatal: not in a git repository`  문제 해결
	



- 다른 workflow에서 재사용 될 경우 checkout 선행이 필요 없어짐
(이후에 target_branch 로 checkout 하는 과정이 있어 중복 checkout 불필요)

## Test

> **💡** _진행한 테스트에 대해서 구체적으로 작성해주세요._

![image](https://user-images.githubusercontent.com/82504981/205841938-0a6940d9-5f34-45dd-ab91-b294ba04e0d6.png)

다른 프로젝트(alpha-actions)에서 reusable workflow 로 사용 할 때 actions-login 브랜치로 동작하도록 하여
actions 동작을 확인하였습니다!
